### PR TITLE
Fix inconsistency in HTML table accessibility

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/table_accessibility/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/table_accessibility/index.md
@@ -137,9 +137,9 @@ A caption is placed directly beneath the `<table>` tag.
 
 ### Active learning: Adding a caption
 
-Let's try this out, revisiting an example we first met in the previous article.
+Let's try this out, using a language teacher's school timetable as an example.
 
-1. Open up your language teacher's school timetable from the end of [HTML table basics](/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics#active_learning_colgroup_and_col), or make a local copy of our [timetable-fixed.html](https://github.com/mdn/learning-area/blob/main/html/tables/basic/timetable-fixed.html) file.
+1. Make a local copy of our [timetable-fixed.html](https://github.com/mdn/learning-area/blob/main/html/tables/basic/timetable-fixed.html) file.
 2. Add a suitable caption for the table.
 3. Save your code and open it in a browser to see what it looks like.
 


### PR DESCRIPTION
### Description

There is a small inconsistency in the text.

From [HTML table accessibility](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/Table_accessibility):

> Let's try this out, revisiting an example we first met in the previous article.
> 
> Open up your language teacher's school timetable from the end of [HTML table basics](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics#active_learning_colgroup_and_col), or make a local copy of our [timetable-fixed.html](https://github.com/mdn/learning-area/blob/main/html/tables/basic/timetable-fixed.html) file.

But it seems there is no mention of language teacher's timetable example in [table basics](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics) at all. Either something is missing there and should be added, or the text in [table accessibility](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/Table_accessibility) should be fixed.

I changed it to

> Let's try this out, using a language teacher's school timetable as an example.
> 
> 1. Make a local copy of our [timetable-fixed.html](https://github.com/mdn/learning-area/blob/main/html/tables/basic/timetable-fixed.html) file.

Please, edit or rewrite if needed.
